### PR TITLE
ACP2E-1198: [Documentation] Page builder doesn't support scopes.

### DIFF
--- a/help/product-recommendations/install-configure.md
+++ b/help/product-recommendations/install-configure.md
@@ -32,6 +32,10 @@ composer require magento/module-page-builder-product-recommendations
 
 By enabling [!DNL Product Recommendations] in Page Builder, you can add an existing, active [recommendation unit](https://docs.magento.com/user-guide/cms/page-builder-add-recommendations.html) to any content created in Page Builder, such as pages, blocks, and dynamic blocks.
 
+   >[!NOTE]
+   >
+   > Page Builder recommendation units can be created only for the default store view.
+
 ### Add Visual similarity recommendation type {#vissimsupport}
 
 The _Visual similarity_ recommendation type allows you to deploy a recommendation unit to your product detail page that displays products that are [visually similar](type.md#visualsim) to the product being viewed. This recommendation type is most useful where images and visual aspects of the products are important parts of the shopping experience. Install the _Visual similarity_ recommendation type by running the following command:

--- a/help/product-recommendations/onboarding.md
+++ b/help/product-recommendations/onboarding.md
@@ -28,6 +28,10 @@ The onboarding process for [!DNL Product Recommendations] requires access to the
 
 [!DNL Product Recommendations] can be added to a page as a Page Builder content type. To add Page Builder support to Product Recommendations, refer to [Install and Configure](install-configure.md).
 
+   >[!NOTE]
+   >
+   > Page Builder recommendation units can be created only for the default store view.
+
 ### B2B support {#b2bsupport}
 
 B2B storefronts often require complex logic that dictates product visibility and pricing for each shopper or customer group. [!DNL Product Recommendations] now [support](release-notes.md) this functionality by honoring [category permissions](https://docs.magento.com/user-guide/catalog/category-permissions.html), [shared catalogs](https://docs.magento.com/user-guide/catalog/catalog-shared.html), and [customer group-specific pricing](https://docs.magento.com/user-guide/catalog/pricing-advanced.html). For example, if you have hidden certain categories from your retail customer segment, then a shopper in that segment would not be shown recommendations for products in those categories. Also, when you define a shared catalog for specific customer groups and companies, those shoppers see recommendations only for products they can access. All recommended products reflect correct customer group-specific price based on each shopper's customer group.


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

According to PO recommendation from ACP2E-1161 ticked we need to update Product Recommendations in Page Builder documentation by adding that Page Builder doesn't support scopes, thus Product Recommendations units can be only assigned to be displayed on a default store view.

PO comment [here|https://jira.corp.adobe.com/browse/ACP2E-1161?focusedCommentId=32605765&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-32605765]

Information is already present on following pages:
- https://experienceleague.adobe.com/docs/commerce-admin/page-builder/add-content/recommendations.html
- https://experienceleague.adobe.com/docs/commerce-merchant-services/product-recommendations/admin/create.html?lang=en

Text to add:
{code}
   >[!NOTE]
   >
   > Page Builder recommendation units can be created only for the default store view.
{code}

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

- Magento 2.4.x

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- No.

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- Product Recommendations.

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

- https://experienceleague.adobe.com/docs/commerce-merchant-services/product-recommendations/getting-started/onboarding.html?lang=en
- https://experienceleague.adobe.com/docs/commerce-merchant-services/product-recommendations/getting-started/install-configure.html?lang=en